### PR TITLE
Upgrade facebook sdk to version 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.2.0
+
+### Changed
+
+- Upgraded Android dependencies: 18.+ for Facebook SDK. Please update your AndroidManifest.xml and strings.xml according to the readme.
+
 ## 3.1.0
 
 ### Changed

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@klippa/nativescript-login",
-	"version": "3.1.0",
+	"version": "3.2.0",
 	"description": "The best way to do social logins in NativeScript, a plugin with modern SDKs to allow authentication to various providers with access to all SDK features",
 	"main": "login",
 	"typings": "index.d.ts",

--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -13,6 +13,6 @@ dependencies {
     def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : "18.0.0"
     implementation "com.google.android.gms:play-services-auth:$googlePlayServicesVersion"
 
-    def facebookSDKVersion = project.hasProperty('facebookSDKVersion') ? project.facebookSDKVersion : "12.+"
+    def facebookSDKVersion = project.hasProperty('facebookSDKVersion') ? project.facebookSDKVersion : "18.+"
     implementation "com.facebook.android:facebook-login:$facebookSDKVersion"
 }

--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,2 +1,2 @@
 pod 'GoogleSignIn','~> 5.0'
-pod 'FBSDKLoginKit','~> 12.0'
+pod 'FBSDKLoginKit','~> 18.0'


### PR DESCRIPTION

Upgraded facebook dependencies to the most recent packages, to avoid conflicts with other nativescript packages such as firebase 


